### PR TITLE
More 32-bit fixes

### DIFF
--- a/bin/hotspots.ml
+++ b/bin/hotspots.ml
@@ -79,7 +79,7 @@ end
 
 module Loc_tbl = Hashtbl.Make (struct
   type t = Location_code.t
-  let hash (x : Location_code.t) = ((x :> int) * 1341797927) lsr 17
+  let hash (x : Location_code.t) = ((x :> int) * 218854569) lsr 17
   let equal (x : Location_code.t) (y : Location_code.t) = (x = y)
 end)
 
@@ -109,7 +109,7 @@ and func = {
 
 module Func_tbl = Hashtbl.Make (struct
   type t = func
-  let hash (f : func) = f.id * 49032809481
+  let hash (f : func) = f.id * 21089245
   let equal (f : func) (g : func) = f.id = g.id
 end)
 

--- a/src/geometric_sampler.ml
+++ b/src/geometric_sampler.ml
@@ -18,7 +18,7 @@ let make ?(rand = default_rand ()) ~sampling_rate () =
    error introduced by the original approximation *)
 
 let log_approx n =
-  let f = Int64.bits_of_float (float_of_int ((n lsl 1) + 1)) in
+  let f = Int64.bits_of_float (Int32.(to_float (add one (shift_left n 1)))) in
   let exp = Int64.(to_int (shift_right f 52)) in
   let exp = float_of_int (exp + (127 - 1023 + 1)) in
   let x = Int64.(float_of_bits (logor (logand f 0xfffffffffffffL) 0x3ff0000000000000L)) in
@@ -31,4 +31,6 @@ let log_approx n =
    (3) Scale the distribution of (2) to have the correct mean by multiplying
    (4) Convert to a geometric distribution by taking the floor + 1 *)
 let draw s =
-  1 + int_of_float (log_approx (Random.State.bits s.rand) *. s.one_log1m_lambda)
+  let uniform_rand = Int32.of_int (Random.State.bits s.rand) in
+  let exp_rand = log_approx uniform_rand in
+  1 + int_of_float (exp_rand *. s.one_log1m_lambda)

--- a/test/dune
+++ b/test/dune
@@ -42,8 +42,14 @@
 ; It will fail whenever the binary format changes.
 ; If you changed the format on purpose, just copy ocamlopt.ctf.copy to ocamlopt.ctf
 
+; Note that we don't guarantee that a 32-bit build can read a capture from a
+; 64-bit build. In particular, >32-bit object identifiers get truncated. Thus we
+; don't expect bit-for-bit accuracy on 32-bit systems. We still do the textual
+; diff above to be sure that readers and writers are consistent.
+
 (rule
  (alias runtest)
+ (enabled_if (= 64 %{ocaml-config:word_size}))
  (deps ocamlopt.ctf ocamlopt.ctf.copy)
  (action (run cmp ocamlopt.ctf ocamlopt.ctf.copy)))
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -39,6 +39,11 @@ let info : Info.t = {
 }
 
 let events : (int * Event.t) list =
+  let big_length =
+    if Int.max_int > 0x3fff_ffff
+      then int_of_string "0x81234567"
+      else 0x31234567
+  in
   [ 0, Alloc {obj_id = id 0;
               length = 42;
               nsamples = 1;
@@ -54,7 +59,7 @@ let events : (int * Event.t) list =
               backtrace_length = 3;
               common_prefix = 2};
     100, Alloc {obj_id = id 2;
-              length = 0x81234567;
+              length = big_length;
               nsamples = 1;
               source = Minor;
               backtrace_buffer = [| loc 0; loc 1; loc 2 |];


### PR DESCRIPTION
* `hotspots.ml`: Use smaller constants when computing hashes
* `geometric_sampler.ml`: Have `log_approx` operate on 32-bit ints
* `test.ml`: Use smaller length on 32-bit systems
* Disable test for bit-for-bit equality on roundtripped .ctf file