### PR TITLE
fix syntax error in TSDL definition

### DIFF
--- a/src/memtrace.tsdl
+++ b/src/memtrace.tsdl
@@ -219,7 +219,7 @@ typealias struct {
   } v;
 } := backtrace_code;
 
-enum allocation_source : uint8 { MINOR=0, MAJOR=1, EXTERNAL=2 }
+typealias enum : uint8 { MINOR=0, MAJOR=1, EXTERNAL=2 } := allocation_source;
 
 event {
   id = 2;


### PR DESCRIPTION
Was using the TSDL to debug a corruption issue under babeltrace, turns out it's malformed since the most recent change.