### PR TITLE
Disable on fork

### DIFF
--- a/src/trace.ml
+++ b/src/trace.ml
@@ -75,7 +75,7 @@ type ctf_header_offsets =
     off_alloc_begin : Write.position_64;
     off_alloc_end : Write.position_64 }
 
-let put_ctf_header b getpid cache =
+let put_ctf_header b pid cache =
   let open Write in
   put_32 b 0xc1fc1fc1l;
   let off_packet_size = skip_32 b in
@@ -83,7 +83,7 @@ let put_ctf_header b getpid cache =
   let off_timestamp_end = skip_64 b in
   let off_flush_duration = skip_32 b in
   put_16 b memtrace_version;
-  put_64 b (getpid ());
+  put_64 b pid;
   begin match cache with
   | Some c -> Backtrace_codec.Writer.put_cache_verifier c b
   | None -> Backtrace_codec.Writer.put_dummy_verifier b
@@ -306,10 +306,11 @@ let make_writer dest ?getpid (info : Info.t) =
   let getpid = match getpid with
     | Some getpid -> getpid
     | None -> fun () -> info.pid in
+  let pid = getpid () in
   let packet = Write.of_bytes (Bytes.make max_packet_size '\042') in
   begin
     (* Write the trace info packet *)
-    let hdr = put_ctf_header packet getpid None in
+    let hdr = put_ctf_header packet pid None in
     put_trace_info packet info;
     finish_ctf_header hdr packet
       ~timestamp_begin:info.start_time
@@ -319,7 +320,7 @@ let make_writer dest ?getpid (info : Info.t) =
     write_fd dest packet;
   end;
   let packet = Write.of_bytes packet.buf in
-  let packet_header = put_ctf_header packet getpid None in
+  let packet_header = put_ctf_header packet pid None in
   let cache = Backtrace_codec.Writer.create () in
   let debug_reader_cache =
     if cache_enable_debug then
@@ -328,7 +329,7 @@ let make_writer dest ?getpid (info : Info.t) =
       None in
   let s =
     { dest;
-      pid = getpid ();
+      pid;
       getpid;
       loc_writer = Location_codec.Writer.create ();
       new_locs = [| |];
@@ -433,7 +434,7 @@ let flush_at s ~now =
   let i = ref 0 in
   while !i < s.new_locs_len do
     let b = Write.of_bytes s.new_locs_buf in
-    let hdr = put_ctf_header b s.getpid None in
+    let hdr = put_ctf_header b s.pid None in
     while !i < s.new_locs_len
           && remaining b > Location_codec.Writer.max_length do
       put_event_header b Ev_location s.packet_time_start;
@@ -460,7 +461,7 @@ let flush_at s ~now =
   s.new_locs_len <- 0;
   s.packet <- Write.of_bytes s.packet.buf;
   s.start_alloc_id <- s.next_alloc_id;
-  s.packet_header <- put_ctf_header s.packet s.getpid (Some s.cache)
+  s.packet_header <- put_ctf_header s.packet s.pid (Some s.cache)
 
 let max_ev_size =
   100 (* upper bound on fixed-size portion of events

--- a/src/trace.mli
+++ b/src/trace.mli
@@ -108,10 +108,12 @@ end
 (** Writing traces *)
 module Writer : sig
   type t
+  exception Pid_changed
   val create : Unix.file_descr -> ?getpid:(unit -> int64) -> Info.t -> t
 
   (** All of the functions below may raise Unix_error if
-      writing to the file descriptor fails *)
+      writing to the file descriptor fails, or Pid_changed
+      if getpid returns a different value. *)
 
   val put_alloc :
     t

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
-(executables (names test trace copy geom_sampler) (libraries memtrace))
+(executables (names test trace copy fork geom_sampler) (libraries memtrace))
 
 (rule
   (alias runtest)
@@ -7,6 +7,10 @@
 (rule
   (alias runtest)
   (action (run ./trace.exe)))
+
+(rule
+  (alias runtest)
+  (action (run ./fork.exe)))
 
 (rule (action (with-stdout-to geom_sampler.out (run ./geom_sampler.exe))))
 

--- a/test/fork.ml
+++ b/test/fork.ml
@@ -1,0 +1,37 @@
+let test_fork ~quick_exit () =
+  let filename = Filename.temp_file "memtrace" "ctf" in
+  Unix.putenv "MEMTRACE" filename;
+  let tr = Memtrace.start_tracing ~context:None ~sampling_rate:1. ~filename in
+  let alloc_before = 1234 and alloc_after = 7364 and alloc_child = 42 in
+  let _ = Sys.opaque_identity Array.make alloc_before "a" in
+  begin match Unix.fork () with
+  | 0 ->
+     begin
+       let count = if quick_exit then 1 else 1000000 in
+       for _i = 1 to count do
+         ignore (Sys.opaque_identity Array.make alloc_child "a")
+       done;
+       exit 0
+     end
+  | pid ->
+     match Unix.waitpid [] pid with
+     | _, WEXITED 0 -> ()
+     | _ -> assert false
+  end;
+  let _ = Sys.opaque_identity Array.make alloc_after "a" in
+  Memtrace.stop_tracing tr;
+
+  let module R = Memtrace.Trace.Reader in
+  let tr = R.open_ ~filename in
+  let sizes = Hashtbl.create 20 in
+  R.iter tr (fun _time ev ->
+    match ev with
+    | Alloc a -> Hashtbl.add sizes a.length ()
+    | _ -> ());
+  assert (Hashtbl.mem sizes alloc_before);
+  assert (Hashtbl.mem sizes alloc_after);
+  assert (not (Hashtbl.mem sizes alloc_child));
+  ()
+
+let () = test_fork ~quick_exit:false ()
+let () = test_fork ~quick_exit:true ()

--- a/test/trace.ml
+++ b/test/trace.ml
@@ -2,7 +2,7 @@ let check_errors () =
   Unix.putenv "MEMTRACE" "/bad/file/name";
   (match Memtrace.trace_if_requested () with
    | _ -> assert false
-   | exception (Unix.Unix_error _) -> ());
+   | exception (Invalid_argument _) -> ());
   Unix.putenv "MEMTRACE" "/tmp/goodfilename";
   (match Memtrace.trace_if_requested ~sampling_rate:(-3.) () with
    | _ -> assert false
@@ -17,6 +17,8 @@ let check_errors () =
   (match Memtrace.trace_if_requested () with
    | _ -> assert false
    | exception (Invalid_argument _) -> ())
+
+let () = check_errors ()
 
 let rec long_bt = function
   | 0 -> (Array.make 1000 0).(42)
@@ -69,7 +71,6 @@ let go () =
   assert (650 <= !ext_samples && !ext_samples < 750);
   assert (not !first);
   assert (!n_long = 10)
-
 
 let () =
   go (); go ()


### PR DESCRIPTION
This patch causes Memtrace to turn itself off if the PID changes, so that if tracing is active across a call to fork then the child process writes no further events, instead of risking corruption of the trace file with two concurrent writers.

The implementation reuses the existing mechanism for disabling Memtrace if flushing fails: in the existing code, if any tracing operation raises an exception then a backtrace is printed to stderr and future tracing is disabled. The only difference here is that if tracing is disabled due to a PID change, no message is printed to stderr.