### PR TITLE
Support 5.3 statmemprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,40 @@ command-line tools in bin/, but the recommended interface is the
 memtrace viewer, which lives at:
 
     https://github.com/janestreet/memtrace_viewer
+
+## Installation
+These instructions are for using statmemprof with OCaml 5.3.0+trunk
+
+``` shell
+# Setup a new Blank switch
+opam switch create 5.3.0 --no-install
+eval $(opam env --switch=5.3.0 --set-switch)
+
+# Install dune
+opam install dune
+```
+
+Now we can get memory traces for programs, here is a multicore fibonacci program:
+
+``` shell
+$ opam instal domainslib
+
+$ dune build examples
+
+# Run tracing on single domain
+$ MEMTRACE=fib_par.ctf _build/default/examples/fib_par.exe 1 45
+
+# On three domains
+$ MEMTRACE=fib_par_2.ctf _build/default/examples/fib_par.exe 3 45
+```
+
+these CTF files are viewable in `memtrace_viewer`.
+
+Install memtrace_viewer in another switch (5.1 will work since we only need to read and write trace files)
+
+``` shell
+opam switch create 5.1.1 --no-install
+opam install memtrace_viewer
+memtrace-viewer ./fib_par_2.ctf
+```
+

--- a/docs/internal.md
+++ b/docs/internal.md
@@ -118,16 +118,16 @@ arbitrary program is hard. There are three standard approaches,
 available as options in `perf record`:
 
   - `--call-graph=dwarf` uses the DWARF debugging information
-    
+
   - `--call-graph=fp` follows a chain of frame pointers
-  
+
   - `--call-graph=lbr` uses the Last Branch Record hardware support
 
 However, all of these have disadvantages:
 
   - DWARF exists to support debuggers, and so is designed for
     flexibility rather than speed.
-    
+
     This flexibility is necessary to handle the hard cases of C stack
     frames: for instance, a C program can define a variable-length
     array of ints on the stack, and store its length (in ints, not

--- a/dune
+++ b/dune
@@ -1,1 +1,1 @@
-(dirs bin src test trace_ocamlopt)
+(dirs bin src test trace_ocamlopt examples)

--- a/dune-project
+++ b/dune-project
@@ -14,4 +14,4 @@
  (synopsis "Streaming client for Memprof")
  (description "Generates compact traces of a program's memory use.")
  (depends
-  (ocaml (>= 4.11.0))))
+  (ocaml (or (>= 5.3.0) (and (>= 4.11.0) (< 5.0))))))

--- a/dune-project
+++ b/dune-project
@@ -14,4 +14,5 @@
  (synopsis "Streaming client for Memprof")
  (description "Generates compact traces of a program's memory use.")
  (depends
+  domainslib
   (ocaml (or (>= 5.3.0) (and (>= 4.11.0) (< 5.0))))))

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,3 @@
+(executables
+ (libraries memtrace domainslib)
+ (names fib_par))

--- a/examples/fib_par.ml
+++ b/examples/fib_par.ml
@@ -1,0 +1,28 @@
+(* fib_par.ml *)
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
+let n = try int_of_string Sys.argv.(2) with _ -> 1
+
+(* Sequential Fibonacci *)
+let rec fib n =
+  if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+
+module T = Domainslib.Task
+
+let rec fib_par pool n =
+  let _ = Buffer.create 10000 in
+  if n > 20 then begin
+      let a = T.async pool (fun _ -> fib_par pool (n-1)) in
+      let b = T.async pool (fun _ -> fib_par pool (n-2)) in
+      T.await pool a + T.await pool b
+    end else
+    (* Call sequential Fibonacci if the available work is small *)
+    fib n
+
+let main () =
+  Memtrace.trace_if_requested ~context:"fib" ();
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) () in
+  let res = T.run pool (fun _ -> fib_par pool n) in
+  T.teardown_pool pool;
+  Printf.printf "fib(%d) = %d\n" n res
+
+let _ = main ()

--- a/memtrace.opam
+++ b/memtrace.opam
@@ -10,6 +10,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
+  "domainslib"
   "ocaml" {>= "5.3.0" | >= "4.11.0" & < "5.0"}
 ]
 build: [

--- a/memtrace.opam
+++ b/memtrace.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "5.3.0" | >= "4.11.0" & < "5.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/memprof_tracer.ml
+++ b/src/memprof_tracer.ml
@@ -106,10 +106,10 @@ let start ?(report_exn=default_report_exn) ~sampling_rate trace =
         | exception e -> mark_failed s e) } in
   curr_active_tracer := Some s;
   bytes_before_ext_sample := draw_sampler_bytes s;
-  Gc.Memprof.start
+  let _t = Gc.Memprof.start
     ~sampling_rate
     ~callstack_size:max_int
-    tracker;
+    tracker in
   s
 
 let stop s =

--- a/src/memprof_tracer.ml
+++ b/src/memprof_tracer.ml
@@ -1,53 +1,39 @@
 type t =
-  { mutable locked : bool;
-    mutable locked_ext : bool;
-    mutable failed : bool;
+  { mutable failed : bool;
     mutable stopped : bool;
+    mutex : Mutex.t;
     report_exn : exn -> unit;
     trace : Trace.Writer.t;
     ext_sampler : Geometric_sampler.t; }
 
-let curr_active_tracer : t option ref = ref None
+let curr_active_tracer : t option Atomic.t  = Atomic.make None
 
-let active_tracer () = !curr_active_tracer
+let active_tracer () = Atomic.get curr_active_tracer
 
-let bytes_before_ext_sample = ref max_int
+let bytes_before_ext_sample = Atomic.make max_int
 
 let draw_sampler_bytes t =
   Geometric_sampler.draw t.ext_sampler * (Sys.word_size / 8)
 
 let[@inline never] rec lock_tracer s =
-  if s.locked then
-    if s.locked_ext then false
-    else (Thread.yield (); lock_tracer s)
+  (* Try unlocking mutex returning true if success or
+     Thread.yield () until it can acquire the mutex successfully.
+   *)
+  if Mutex.try_lock s.mutex then
+    true
   else if s.failed then
     false
   else
-    (s.locked <- true; true)
-
-let[@inline never] rec lock_tracer_ext s =
-  if s.locked then
-    (Thread.yield (); lock_tracer_ext s)
-  else if s.failed then
-    false
-  else
-    (s.locked <- true; s.locked_ext <- true; true)
+    (Thread.yield (); lock_tracer s)
 
 let[@inline never] unlock_tracer s =
-  assert (s.locked && not s.locked_ext && not s.failed);
-  s.locked <- false
-
-let[@inline never] unlock_tracer_ext s =
-  assert (s.locked && s.locked_ext && not s.failed);
-  s.locked_ext <- false;
-  s.locked <- false
+  assert (not s.failed);
+  Mutex.unlock s.mutex
 
 let[@inline never] mark_failed s e =
-  assert (s.locked && not s.failed);
   s.failed <- true;
-  s.locked <- false;
-  s.locked_ext <- false;
-  s.report_exn e
+  s.report_exn e;
+  Mutex.unlock s.mutex
 
 let default_report_exn e =
   match e with
@@ -63,7 +49,8 @@ let default_report_exn e =
 
 let start ?(report_exn=default_report_exn) ~sampling_rate trace =
   let ext_sampler = Geometric_sampler.make ~sampling_rate () in
-  let s = { trace; locked = false; locked_ext = false; stopped = false; failed = false;
+  let mutex = Mutex.create () in
+  let s = { trace; mutex; stopped = false; failed = false;
             report_exn; ext_sampler } in
   let tracker : (_,_) Gc.Memprof.tracker = {
     alloc_minor = (fun info ->
@@ -75,8 +62,11 @@ let start ?(report_exn=default_report_exn) ~sampling_rate trace =
                 ~callstack:info.callstack
         with
         | r -> unlock_tracer s; Some r
-        | exception e -> mark_failed s e; None
-      end else None);
+        | exception e ->
+           mark_failed s e;
+           None
+        end
+      else None);
     alloc_major = (fun info ->
       if lock_tracer s then begin
         match Trace.Writer.put_alloc_with_raw_backtrace trace (Trace.Timestamp.now ())
@@ -104,68 +94,64 @@ let start ?(report_exn=default_report_exn) ~sampling_rate trace =
         match Trace.Writer.put_collect trace (Trace.Timestamp.now ()) id with
         | () -> unlock_tracer s
         | exception e -> mark_failed s e) } in
-  curr_active_tracer := Some s;
-  bytes_before_ext_sample := draw_sampler_bytes s;
-  let _t = Gc.Memprof.start
-    ~sampling_rate
-    ~callstack_size:max_int
-    tracker in
+  Atomic.set curr_active_tracer (Some s);
+  Atomic.set bytes_before_ext_sample (draw_sampler_bytes s);
+  ignore (Gc.Memprof.start ~sampling_rate ~callstack_size:max_int tracker);
   s
 
 let stop s =
   if not s.stopped then begin
     s.stopped <- true;
     Gc.Memprof.stop ();
-    if lock_tracer s then begin
-      try Trace.Writer.close s.trace with e -> mark_failed s e
-    end;
-    curr_active_tracer := None
+    Mutex.protect s.mutex (fun () ->
+        try Trace.Writer.close s.trace
+        with e ->
+          (s.failed <- true; s.report_exn e);
+        Atomic.set curr_active_tracer None
+      )
   end
 
 let[@inline never] ext_alloc_slowpath ~bytes =
-  match !curr_active_tracer with
-  | None -> bytes_before_ext_sample := max_int; None
+  match Atomic.get curr_active_tracer with
+  | None -> Atomic.set bytes_before_ext_sample max_int; None
   | Some s ->
-    if lock_tracer_ext s then begin
+    if lock_tracer s then begin
       match
         let bytes_per_word = Sys.word_size / 8 in
         (* round up to an integer number of words *)
         let size_words = (bytes + bytes_per_word - 1) / bytes_per_word in
-        let samples = ref 0 in
-        while !bytes_before_ext_sample <= 0 do
-          bytes_before_ext_sample :=
-            !bytes_before_ext_sample + draw_sampler_bytes s;
-          incr samples
+        let samples = Atomic.make 0 in
+        while Atomic.get bytes_before_ext_sample <= 0 do
+          ignore (Atomic.fetch_and_add bytes_before_ext_sample (draw_sampler_bytes s));
+          Atomic.incr samples
         done;
-        assert (!samples > 0);
+        assert (Atomic.get samples > 0);
         let callstack = Printexc.get_callstack max_int in
         Some (Trace.Writer.put_alloc_with_raw_backtrace s.trace
                 (Trace.Timestamp.now ())
                 ~length:size_words
-                ~nsamples:!samples
+                ~nsamples:(Atomic.get samples)
                 ~source:External
                 ~callstack)
       with
-      | r -> unlock_tracer_ext s; r
+      | r -> unlock_tracer s; r
       | exception e -> mark_failed s e; None
     end else None
-
 
 type ext_token = Trace.Obj_id.t
 
 let ext_alloc ~bytes =
-  let n = !bytes_before_ext_sample - bytes in
-  bytes_before_ext_sample := n;
+  let n = Atomic.fetch_and_add bytes_before_ext_sample (- bytes) in
   if n <= 0 then ext_alloc_slowpath ~bytes else None
 
 let ext_free id =
-  match !curr_active_tracer with
+  match Atomic.get curr_active_tracer with
   | None -> ()
   | Some s ->
-    if lock_tracer_ext s then begin
+    if lock_tracer s then begin
       match
         Trace.Writer.put_collect s.trace (Trace.Timestamp.now ()) id
       with
-      | () -> unlock_tracer_ext s; ()
+      | () -> unlock_tracer s; ()
       | exception e -> mark_failed s e; ()
     end

--- a/src/memtrace.ml
+++ b/src/memtrace.ml
@@ -61,7 +61,7 @@ let trace_if_requested ?context ?sampling_rate () =
      let sampling_rate =
        match Sys.getenv_opt "MEMTRACE_RATE" with
        | Some rate -> check_rate (float_of_string_opt rate)
-       | None | Some "" ->
+       | None ->
          match sampling_rate with
          | Some _ -> check_rate sampling_rate
          | None -> default_sampling_rate


### PR DESCRIPTION
This PR makes the minimal amount of changes to support https://github.com/ocaml/ocaml/pull/12923

 * 054d24aba83971a18eeac7b3e7e84cd007f0d6cb makes the code changes to be compatible with 4.14 and 5.3 statmemprof implementations
 * 10fd2ebe7be0805151ac5ba5e022019c17646f98 is documentation for using statmemprof with https://github.com/ocaml/ocaml/pull/12923 (this can be discarded when 5.3 is released)
 
I want to fix the `raw_backtrace` code to use the new functions in https://github.com/ocaml/ocaml/pull/9663