### PR TITLE
Unlock shared writer after close

### DIFF
--- a/src/buf.ml
+++ b/src/buf.ml
@@ -32,11 +32,12 @@ module Shared_writer_fd = struct
 
   let close t =
     Mutex.lock t.lock;
-    Atomic.set t.closed true;
-    try Unix.close t.fd with
-    | (_ : exn) ->
-      ();
-      Mutex.unlock t.lock
+    Fun.protect
+      (fun () ->
+        Atomic.set t.closed true;
+        try Unix.close t.fd with
+        | (_ : exn) -> ())
+      ~finally:(fun () -> Mutex.unlock t.lock)
   ;;
 end
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -197,5 +197,18 @@ let test_failure () =
   if not (Atomic.get got_epipe) then failwith "should have failed"
 ;;
 
+let test_close_unlocks_shared_writer () =
+  with_temp
+  @@ fun fd ->
+  let shared = Memtrace__Buf.Shared_writer_fd.make fd in
+  Memtrace__Buf.Shared_writer_fd.close shared;
+  match
+    Memtrace__Buf.Shared_writer_fd.write_fully shared (Bytes.create 0) ~pos:0 ~len:0
+  with
+  | () -> failwith "write after close should fail"
+  | exception Memtrace__Buf.Shared_writer_fd.Closed -> ()
+;;
+
 let () = test ()
 let () = test_failure ()
+let () = test_close_unlocks_shared_writer ()


### PR DESCRIPTION
Fixes #25.

`Shared_writer_fd.close` acquired the writer mutex but released it only when `Unix.close` raised. On the usual successful path, later writers waited forever before they could observe `Closed`.

Wrap the best-effort close in `Fun.protect` so the mutex is always released. The regression closes a shared writer and then checks that a later write raises `Closed` instead of blocking.

Validation:
- `git diff --check`
- private Linux runner: installed OCaml 5.2.1 and `ppx_jane`, then ran `dune build @all -j2`; compilation reaches the repository sources but the public toolchain cannot compile existing `Domain.Safe` and `Sys.Safe` uses and existing warning-as-error findings, so `dune runtest` is not reachable outside the Jane Street build environment
