### PR TITLE
Close reader descriptor after open errors

### DIFF
--- a/src/trace.ml
+++ b/src/trace.ml
@@ -1115,7 +1115,17 @@ module Reader = struct
   ;;
 
   let iter = iter
-  let open_ ~filename = make_reader (Unix.openfile filename [ Unix.O_RDONLY ] 0)
+
+  let open_ ~filename =
+    let fd = Unix.openfile filename [ Unix.O_RDONLY ] 0 in
+    match make_reader fd with
+    | reader -> reader
+    | exception exn ->
+      (try Unix.close fd with
+       | (_ : exn) -> ());
+      raise exn
+  ;;
+
   let size_bytes s = (Unix.LargeFile.fstat s.fd).st_size
   let close s = Unix.close s.fd
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -197,5 +197,26 @@ let test_failure () =
   if not (Atomic.get got_epipe) then failwith "should have failed"
 ;;
 
+let test_reader_open_failure_closes_fd () =
+  if Sys.file_exists "/proc/self/fd"
+  then (
+    let filename = Filename.temp_file "memtrace" "invalid-ctf" in
+    Fun.protect
+      ~finally:(fun () -> if Sys.file_exists filename then Unix.unlink filename)
+      (fun () ->
+        let count_open_file_descriptors () = Array.length (Sys.readdir "/proc/self/fd") in
+        let before = count_open_file_descriptors () in
+        for _i = 1 to 10 do
+          match Reader.open_ ~filename with
+          | reader ->
+            Reader.close reader;
+            failwith "empty trace should not open"
+          | exception _ -> ()
+        done;
+        let after = count_open_file_descriptors () in
+        if before <> after then failwith "Reader.open_ leaked file descriptors"))
+;;
+
 let () = test ()
 let () = test_failure ()
+let () = test_reader_open_failure_closes_fd ()


### PR DESCRIPTION
Fixes #27.

`Reader.open_` opened a descriptor and passed it directly into trace-header parsing. If a truncated or malformed trace raised during `make_reader`, the caller never received a reader value and had no descriptor to close.

Close the descriptor best-effort on the exception path and re-raise the original parsing exception. Successful readers retain ownership exactly as before.

The Linux regression opens an invalid trace ten times and checks `/proc/self/fd` before and after the loop, so the failure path must leave the descriptor count flat.

Validation:
- `git diff --check`
- private Linux runner: installed OCaml 5.2.1 and `ppx_jane`, then ran `dune build @all -j2`; compilation reaches the repository sources but the public toolchain cannot compile existing `Domain.Safe` and `Sys.Safe` uses and existing warning-as-error findings, so `dune runtest` is not reachable outside the Jane Street build environment
